### PR TITLE
Fix emails not sending v1.12

### DIFF
--- a/class.ResponderPlugin.php
+++ b/class.ResponderPlugin.php
@@ -107,8 +107,7 @@ class ResponderPlugin extends Plugin {
    */
   private function post_reply(Ticket $ticket, PluginConfig $config) {
     $robot = Staff::lookup($config->get('sender'));
-    $reply = Canned::lookup($config->get('response'))->getFormattedResponse(
-      'html');
+    $reply = Canned::lookup($config->get('response'));
 
     // We need to override this for the notifications
     global $thisstaff;
@@ -120,17 +119,18 @@ class ResponderPlugin extends Plugin {
     $thisstaff = $robot;
 
     // Replace any ticket variables in the message:
-    $variables = [
-        'recipient' => $ticket->getOwner()
-    ];
+//     $variables = [
+//         'recipient' => $ticket->getOwner()
+//     ];
 
-    $vars = [
-        'response' => $ticket->replaceVars($reply, $variables)
-    ];
-    $errors = [];
+//     $vars = [
+//         'response' => $ticket->replaceVars($reply, $variables)
+//     ];
+//     $errors = [];
+    $msg = $ticket->getThreadId();
 
     // Send the alert without claiming the ticket on our assignee's behalf.
-    if (! $sent = $ticket->postReply($vars, $errors, TRUE, FALSE)) {
+    if (! $sent = $ticket->postCannedReply($reply,$msg,true)) {
       $ticket->LogNote(__('Error Notification'),
         __('We were unable to post a reply to the ticket creator.'),
         self::PLUGIN_NAME, FALSE);


### PR DESCRIPTION
I made a change to the plugin, instead of using `postReply()` I changed it to `postCannedReply()` that way the core takes care of the reply and getting the canned response.
I believe that the recent update to 1.12 added some vars to `postReply()`

Thanks @clonemeagain for making the plugin in the first place
its my second contribution to open source witch i enjoy so much all the time, i'm open to any suggestions 

this should fix #3